### PR TITLE
Не оптимально обращение к базе. 

### DIFF
--- a/example/ex.pl
+++ b/example/ex.pl
@@ -15,12 +15,16 @@ my $geo = Geo::SypexGeo->new( 'data/SxGeoCity.dat' );
 
 my $city;
 
-$city = $geo->get_city( '87.250.250.203', 'en' );
+$geo->parse( '87.250.250.203', 'en' ) or die "Cant parse 87.250.250.203";
+$city = $geo->get_city();
 say $city;
 
-$city = $geo->get_city( '93.191.14.81' );
+$geo->parse( '93.191.14.81' ) or die "Cant parse 93.191.14.81";
+$city = $geo->get_city();
 say $city;
-
-my $country = $geo->get_country( '93.191.14.81' );
+my $country = $geo->get_country();
 say $country;
+my ($latitude, $longitude) = $geo->get_coordinates();
+say "Latitude: $latitude Longitude: $longitude";
+
 

--- a/lib/Geo/SypexGeo.pm
+++ b/lib/Geo/SypexGeo.pm
@@ -1,6 +1,6 @@
 package Geo::SypexGeo;
 
-our $VERSION = '0.4';
+our $VERSION = '0.5';
 
 use strict;
 use warnings;
@@ -16,7 +16,7 @@ use Text::Trim;
 use fields qw(
   db_file b_idx_str m_idx_str range b_idx_len m_idx_len db_items id_len
   block_len max_region max_city db_begin regions_begin cities_begin
-  max_country country_size pack
+  max_country country_size pack info
 );
 
 use constant {
@@ -100,10 +100,7 @@ sub get_city {
   my $ip               = shift;
   my $lang             = shift;
 
-  my $seek = $self->get_num($ip);
-  return unless $seek;
-
-  my $info = $self->parse_info( $seek, $lang );
+  my $info = $self->{info} || $self->get_info($ip, $lang);
   return unless $info;
 
   my $city;
@@ -122,14 +119,22 @@ sub get_country {
   my __PACKAGE__ $self = shift;
   my $ip = shift;
 
-  my $seek = $self->get_num($ip);
-  return unless $seek;
-
-  my $info = $self->parse_info($seek);
+  my $info = $self->{info} || $self->get_info($ip);
   return unless $info;
 
   my $country = $COUNTRY_ISO_MAP[ $info->[1] ];
   return $country;
+}
+
+sub get_info {
+  my __PACKAGE__ $self = shift;
+  my $ip = shift;
+  my $lang = shift;
+  my $seek = $self->get_num($ip);
+  return unless $seek;
+
+  $self->{info} = $self->parse_info($seek, $lang);
+  return $self->{info};
 }
 
 sub get_num {

--- a/lib/Geo/SypexGeo.pm
+++ b/lib/Geo/SypexGeo.pm
@@ -266,7 +266,7 @@ sub parse_info {
     open( my $fl, $self->{db_file} ) || croak('Could not open db file');
     binmode $fl, ':bytes';
     seek $fl, $seek + $self->{cities_begin}, 0;
-    read $fl, my $buf, $self->{max_region};
+    read $fl, my $buf, $self->{max_country};
     close $fl;
 
     $info = extended_unpack( $self->{pack}[0], $buf );
@@ -275,7 +275,7 @@ sub parse_info {
     open( my $fl, $self->{db_file} ) || croak('Could not open db file');
     binmode $fl, ':bytes';
     seek $fl, $seek + $self->{cities_begin}, 0;
-    read $fl, my $buf, $self->{max_region};
+    read $fl, my $buf, $self->{max_city};
     close $fl;
 
     $info = extended_unpack( $self->{pack}[2], $buf );


### PR DESCRIPTION
При поиске информации о городе и о стране, по одному айпи, производится два запроса к БД, хотя в ответ получается один и тот же массив.
 
Добавлен метод parse, который осуществляет поиск информации об объекте в базе и запись полученного массива с данными в ->{info}. Далее вызов методов get_city и get_country происходит без обращения к базе, в этих методах производится только парсинг ранее полученных данных.

Добавлен метод get_coordinates, возвращающий географические координаты (широта и долгота) объекта, в виде массива из двух элементов